### PR TITLE
existing post check bugfix for custom post types

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -1264,6 +1264,7 @@ class SyndicatedPost {
 				'fields' => '_synfresh', // id, guid, post_modified_gmt
 				'ignore_sticky_posts' => true,
 				'guid' => $guid,
+				'post_type' => 'any',
 			));
 			
 			$old_post = NULL;


### PR DESCRIPTION
check for pre-existing posts worked only when using "post" post-type - added 'post_type' => 'any' to query (alternative would have been to check against specific post type… which might make sense on huge sites?)
