### PR TITLE
Fix Syndication data query when postmeta table uses non-default name

### DIFF
--- a/syndicationdataqueries.class.php
+++ b/syndicationdataqueries.class.php
@@ -94,7 +94,7 @@ class SyndicationDataQueries {
 			// checks -- for reasons of both performance and correctness. Pitch:
 			$search .= " -- '";
 		elseif ($query->get('fields')=='_synfrom') :
-			$search .= " AND ({$wpdb->postmeta}.meta_key = '".$query->get('meta_key')."' AND wp_postmeta.meta_value = '".$query->get('meta_value')."') -- '"; 
+			$search .= " AND ({$wpdb->postmeta}.meta_key = '".$query->get('meta_key')."' AND {$wpdb->postmeta}.meta_value = '".$query->get('meta_value')."') -- '"; 
 		endif;
 		return $search;
 	} /* SyndicationDataQueries::posts_search () */


### PR DESCRIPTION
Especially useful for when wordpress is installed to use a different table name prefix
