### PR TITLE
Extend author lookup to search prefixed usermeta

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -2011,9 +2011,9 @@ EOM;
 				$id = $wpdb->get_var(
 				"SELECT user_id FROM $wpdb->usermeta
 				WHERE
-					(meta_key = 'description' AND TRIM(LCASE(meta_value)) = TRIM(LCASE('$author')))
+					(meta_key LIKE 'fwp%' AND TRIM(LCASE(meta_value)) = TRIM(LCASE('$author')))
 					OR (
-						meta_key = 'description'
+						meta_key LIKE 'fwp%'
 						AND TRIM(LCASE(meta_value))
 						RLIKE CONCAT(
 							'(^|\\n)a\\.?k\\.?a\\.?( |\\t)*:?( |\\t)*',


### PR DESCRIPTION
In community sites often authors can provide additional handles on 3rd
party services. For sites that want to use these aliases when matching
authors to posts in general activity feeds admins could configure
selected usermeta fields by prefixing with fwp which would be used in the
lookup.
