### PR TITLE
Fix permissions to erase/resyndicate and trash

### DIFF
--- a/feedwordpress.php
+++ b/feedwordpress.php
@@ -1415,7 +1415,7 @@ class FeedWordPress {
 	} /* FeedWordPress::redirect_retired () */
 
 	public function row_actions ($actions, $post) {
-		if (is_syndicated($post->ID)) :
+		if (is_syndicated($post->ID) && current_user_can('edit_post', $post->ID)) :
 			$link = get_delete_post_link($post->ID, '', true);
 			$link = MyPHP::url($link, array("fwp_post_delete" => "nuke"));
 


### PR DESCRIPTION
Users with author permissions are currently able to erase/resyndicate any post whether they are the author of that post or not. The author permission should only have permissions to modify a post that they have created.