### PR TITLE
Fixed Bug on line 68 of admin-ui.php

### DIFF
--- a/admin-ui.php
+++ b/admin-ui.php
@@ -65,7 +65,7 @@ class FeedWordPressAdminPage {
 		$displayUrl = $uri;
 		
 		// check for effects of an effective-url filter
-		$effectiveUrl = $link->uri(array('fetch' => true));
+		$effectiveUrl = $this->link->uri(array('fetch' => true));
 		if ($uri != $effectiveUrl) : $displayUrl .= ' | ' . $effectiveUrl; endif;
 
 		$delta = $feedwordpress->update($uri);


### PR DESCRIPTION
Line 68 throws the following exception when updating feeds;

Fatal Error: Call to a member function uri() on a non-object in C:\path\to\feedwordpress\plugin\admin-ui.php on line 68

So I changed it from [ $effectiveUrl = $link->uri(array('fetch' => true)); ] to [ $effectiveUrl = $this->link->uri(array('fetch' => true)); ] and it works.