### PR TITLE
Add SSL/HTTP Support

### DIFF
--- a/admin-ui.php
+++ b/admin-ui.php
@@ -371,7 +371,7 @@ class FeedWordPressAdminPage {
 	function display_sheet_header ($pagename = 'Syndication', $all = false) {
 		global $fwp_path;
 		?>
-		<div class="icon32"><img src="<?php print esc_html(WP_PLUGIN_URL.'/'.$fwp_path.'/feedwordpress.png'); ?>" alt="" /></div>
+		<div class="icon32"><img src="<?php print esc_html( plugins_url( '/'.$fwp_path.'/feedwordpress.png') ); ?>" alt="" /></div>
 		<h2><?php print esc_html(__($pagename.($all ? '' : ' Settings'))); ?><?php if ($this->for_feed_settings()) : ?>: <?php echo esc_html($this->link->name(/*from feed=*/ false)); ?><?php endif; ?></h2>
 		<?php
 	}
@@ -974,7 +974,7 @@ class FeedWordPressSettingsUI {
 		wp_enqueue_script('post'); // for magic tag and category boxes
 		wp_enqueue_script('admin-forms'); // for checkbox selection
 
-		wp_register_script('feedwordpress-elements', WP_PLUGIN_URL.'/'.$fwp_path.'/feedwordpress-elements.js');
+		wp_register_script('feedwordpress-elements', plugins_url('/' . $fwp_path . '/feedwordpress-elements.js') );
 		wp_enqueue_script('feedwordpress-elements');
 	}
 

--- a/feedwordpress.php
+++ b/feedwordpress.php
@@ -671,7 +671,7 @@ function fwp_add_pages () {
 		$menu_cap,
 		$syndicationMenu,
 		NULL,
-		WP_PLUGIN_URL.'/'.FeedWordPress::path('feedwordpress-tiny.png')
+		plugins_url( '/'.FeedWordPress::path('feedwordpress-tiny.png') )
 	);
 
 	do_action('feedwordpress_admin_menu_pre_feeds', $menu_cap, $settings_cap);
@@ -1465,7 +1465,7 @@ class FeedWordPress {
 		// If this is a FeedWordPress admin page, queue up scripts for AJAX
 		// functions that FWP uses. If it is a display page or a non-FWP admin
 		// page, don't.
-		wp_register_style('feedwordpress-elements', WP_PLUGIN_URL.'/'.$fwp_path.'/feedwordpress-elements.css');
+		wp_register_style('feedwordpress-elements', plugins_url( '/'.$fwp_path.'/feedwordpress-elements.css') );
 		if (FeedWordPressSettingsUI::is_admin()) :
 			// For JavaScript that needs to be generated dynamically
 			add_action('admin_print_scripts', array('FeedWordPressSettingsUI', 'admin_scripts'));

--- a/feedwordpresssyndicationpage.class.php
+++ b/feedwordpresssyndicationpage.class.php
@@ -431,7 +431,7 @@ class FeedWordPressSyndicationPage extends FeedWordPressAdminPage {
 		
 		// Hey ho, let's go...
 		?>
-		<div style="float: left; background: #F5F5F5; padding-top: 5px; padding-right: 5px;"><a href="<?php print $this->form_action(); ?>"><img src="<?php print esc_html(WP_PLUGIN_URL."/${fwp_path}/feedwordpress.png"); ?>" alt="" /></a></div>
+		<div style="float: left; background: #F5F5F5; padding-top: 5px; padding-right: 5px;"><a href="<?php print $this->form_action(); ?>"><img src="<?php print esc_html(plugins_url( "/${fwp_path}/feedwordpress.png") ); ?>" alt="" /></a></div>
 
 		<p class="info" style="margin-bottom: 0px; border-bottom: 1px dotted black;">Managed by <a href="http://feedwordpress.radgeek.com/">FeedWordPress</a>
 		<?php print FEEDWORDPRESS_VERSION; ?>.</p>
@@ -490,7 +490,7 @@ class FeedWordPressSyndicationPage extends FeedWordPressAdminPage {
 		
 		  <?php FeedWordPressSettingsUI::magic_input_tip_js('add-uri'); ?>
 		  <input type="hidden" name="action" value="<?php print FWP_SYNDICATE_NEW; ?>" />
-		  <input style="vertical-align: middle;" type="image" src="<?php print WP_PLUGIN_URL.'/'.$fwp_path; ?>/plus.png" alt="<?php print FWP_SYNDICATE_NEW; ?>" /></div>
+		  <input style="vertical-align: middle;" type="image" src="<?php print plugins_url('/'.$fwp_path .'/plus.png' ); ?>" alt="<?php print FWP_SYNDICATE_NEW; ?>" /></div>
 		  </form>
 		</div> <!-- id="add-single-uri" -->
 		
@@ -556,9 +556,9 @@ class FeedWordPressSyndicationPage extends FeedWordPressAdminPage {
 		
 		  <input type="hidden" name="action" value="feedfinder" />
 		  <input type="submit" class="button-secondary" name="action" value="<?php print FWP_SYNDICATE_NEW; ?>" />
-		  <div style="text-align: right; margin-right: 2.0em"><a id="turn-on-multiple-sources" href="#add-multiple-uri"><img style="vertical-align: middle" src="<?php print WP_PLUGIN_URL.'/'.$fwp_path; ?>/down.png" alt="" /> add multiple</a>
+		  <div style="text-align: right; margin-right: 2.0em"><a id="turn-on-multiple-sources" href="#add-multiple-uri"><img style="vertical-align: middle" src="<?php print plugins_url('/' . $fwp_path . '/down.png'); ?>" alt="" /> add multiple</a>
 		  <span class="screen-reader-text"> or </span>
-		  <a id="turn-on-opml-upload" href="#upload-opml"><img src="<?php print WP_PLUGIN_URL.'/'.$fwp_path; ?>/plus.png" alt="" style="vertical-align: middle" /> import source list</a></div>
+		  <a id="turn-on-opml-upload" href="#upload-opml"><img src="<?php print plugins_url('/' . $fwp_path . '/plus.png'); ?>" alt="" style="vertical-align: middle" /> import source list</a></div>
 		  </li>
 		  </ul>
 		  </form>
@@ -684,12 +684,12 @@ support, and documentation.</p>
 </div> <!-- style="display: inline-block" -->
 
 <div class="hovered-component" style="display: inline-block; vertical-align: bottom">
-<a href="bitcoin:<?php print esc_attr(FEEDWORDPRESS_BLEG_BTC); ?>"><img src="<?php print esc_url(WP_PLUGIN_URL.'/'.FeedWordPress::path('btc-qr-64px.png')); ?>" alt="Donate" /></a>
+<a href="bitcoin:<?php print esc_attr(FEEDWORDPRESS_BLEG_BTC); ?>"><img src="<?php print esc_url( plugins_url('/'.FeedWordPress::path('btc-qr-64px.png') ) ); ?>" alt="Donate" /></a>
 <div><a href="bitcoin:<?php print esc_attr(FEEDWORDPRESS_BLEG_BTC); ?>">via bitcoin<span class="hover-on pop-over" style="background-color: #ddffdd; padding: 5px; color: black; border-radius: 5px;">bitcoin:<?php print esc_html(FEEDWORDPRESS_BLEG_BTC); ?></span></a></div>
 </div>
 
 <div style="display: inline-block; vertical-align: bottom">
-<input type="image" name="submit" src="<?php print esc_url(WP_PLUGIN_URL.'/'.FeedWordPress::path('paypal-donation-64px.png')); ?>" alt="Donate through PayPal" />
+<input type="image" name="submit" src="<?php print esc_url(plugins_url('/' . FeedWordPress::path('paypal-donation-64px.png' ) ) ); ?>" alt="Donate through PayPal" />
 <input type="hidden" name="business" value="distro.to.feedback@radgeek.com"  />
 <input type="hidden" name="cmd" value="_xclick"  />
 <input type="hidden" name="item_name" value="FeedWordPress donation"  />


### PR DESCRIPTION
This pull request replaces `WP_PLUGIN_URL` with `plugins_url()` on all images, JavaScript and CSS being loaded in `wp-admin` this allows for a secure connection when the admin is loaded over https. 