### PR TITLE
Update syndicatedpost.class.php

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -1329,7 +1329,9 @@ class SyndicatedPost {
 			$old_post = NULL;
 			if ($q->have_posts()) :
 				while ($q->have_posts()) : $q->the_post();
-					$old_post = $q->post;
+					if (get_post_type($q->post->ID) == $this->post['post_type']):
+						$old_post = $q->post;
+					endif;
 				endwhile;
 			endif;
 


### PR DESCRIPTION
If you add your own feed to FeedWordPress and set FeedWordPress to store its entries in a custom post type, it won't work: FeedWordPress will use the actual content (which is dangerous because it will overwrite it with the feed content!) instead of creating a new post using the specified custom post type.

This fix is just a safeguard: in all situation, FeedWordPress should only publish the entry to a post matching the post type it was set to.

Also, the documentation should reflect the fact that using your own feed may lead to unexpected behaviors.
On my setup, I use a custom post type dedicated to FeedWordPress. This custom post type is set not to appear in the feed. This way, I avoid problems (except the one I fixed here) but if you don't do that, you may expect some odd behaviors or data corruption.
