### PR TITLE
Fix method visibility

### DIFF
--- a/feedwordpress.php
+++ b/feedwordpress.php
@@ -237,7 +237,7 @@ endif; // if (!FeedWordPress::needs_upgrade())
 ################################################################################
 
 class FeedWordPressDiagnostic {
-	function feed_error ($error, $old, $link) {
+	public static function feed_error ($error, $old, $link) {
 		$wpError = $error['object'];
 		$url = $link->uri();
 		


### PR DESCRIPTION
Fix "Strict Standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method FeedWordPressDiagnostic::feed_error() should not be called statically"