### PR TITLE
Fix use of explicitly set empty string post metavalue

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -163,6 +163,9 @@ class SyndicatedPost {
 			endforeach;
 
 			foreach ($postMetaOut as $key => $values) :
+				if (is_null($values)) { // have chosen to replace value with empty string
+					$values = ['']; 
+				}
 				$this->post['meta'][$key] = array();
 				foreach ($values as $value) :
 					$this->post['meta'][$key][] = apply_filters("syndicated_post_meta_{$key}", $value, $this);

--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -557,7 +557,7 @@ class SyndicatedPost {
 		endif;
 
 		if (!$unfiltered) :
-			apply_filters('syndicated_item_updated', $ts, $this);
+			$ts = apply_filters('syndicated_item_updated', $ts, $this);
 		endif;
 		return $ts;
 	} /* SyndicatedPost::updated() */


### PR DESCRIPTION
There maybe a better way of fixing this, such as changing `do_substitutions()` to  return `['']` instead of `null` for this case, but this fixes the problem with least collateral changes.