### PR TITLE
Remove the whitepace around the period name returned from magpie.

### DIFF
--- a/syndicatedlink.class.php
+++ b/syndicatedlink.class.php
@@ -980,7 +980,7 @@ class SyndicatedLink {
 			// channel format is updated. Acceptable values are:
 			// hourly, daily, weekly, monthly, yearly. If omitted,
 			// daily is assumed." <http://web.resource.org/rss/1.0/modules/syndication/>
-			if (isset($channel['sy']['updateperiod'])) : $period = $channel['sy']['updateperiod'];
+			if (isset($channel['sy']['updateperiod'])) : $period = trim($channel['sy']['updateperiod']);
 			else : $period = 'daily';
 			endif;
 


### PR DESCRIPTION
You can see the difference in the warning messages when the index has newlines:
```
Error Level: E_NOTICE
Message: Undefined index: 
    hourly    
```

compared to a different warning elsewhere in the class:
```
Error Level: E_NOTICE
Message: Undefined index: stored
```