### PR TITLE
Fix for WP_Feed_Cache became depricated in wp5.6, so the cache class …

### DIFF
--- a/extend/SimplePie/feedwordpie.class.php
+++ b/extend/SimplePie/feedwordpie.class.php
@@ -3,8 +3,14 @@ define('FEEDWORDPIE_TYPE_CUSTOM_XML', ~SIMPLEPIE_TYPE_NONE & ~SIMPLEPIE_TYPE_ALL
 
 class FeedWordPie extends SimplePie {
 	var $subscription = NULL;
-	
-	function set_feed_url ($url) {
+
+	function init()
+    {
+        $this->set_cache_location(sys_get_temp_dir());
+        return parent::init();
+    }
+
+    function set_feed_url ($url) {
 		global $fwp_oLinks;
 		if ($url InstanceOf SyndicatedLink) :
 

--- a/extend/SimplePie/feedwordpie_cache.class.php
+++ b/extend/SimplePie/feedwordpie_cache.class.php
@@ -1,0 +1,8 @@
+<?php
+
+class FeedWordPie_Cache  {
+    public static function create( $location, $filename, $extension ) {
+        return new WP_Feed_Cache_Transient( $location, $filename, $extension );
+    }
+}
+

--- a/feedwordpress.php
+++ b/feedwordpress.php
@@ -96,7 +96,6 @@ endif;
 // Dependencies: modules packaged with WordPress core
 $wpCoreDependencies = array(
 "class:SimplePie" => "class-simplepie",
-"class:WP_Feed_Cache" => "class-wp-feed-cache",
 "class:WP_Feed_Cache_Transient" => "class-wp-feed-cache-transient",
 "class:WP_SimplePie_File" => "class-wp-simplepie-file",
 "class:WP_SimplePie_Sanitize_KSES" => "class-wp-simplepie-sanitize-kses",
@@ -143,6 +142,7 @@ require_once("${dir}/syndicationdataqueries.class.php");
 require_once("${dir}/extend/SimplePie/feedwordpie.class.php");
 require_once("${dir}/extend/SimplePie/feedwordpie_item.class.php");
 require_once("${dir}/extend/SimplePie/feedwordpie_file.class.php");
+require_once("${dir}/extend/SimplePie/feedwordpie_cache.class.php");
 require_once("${dir}/extend/SimplePie/feedwordpie_parser.class.php");
 require_once("${dir}/extend/SimplePie/feedwordpie_content_type_sniffer.class.php");
 require_once("${dir}/feedwordpressrpc.class.php");


### PR DESCRIPTION
```WP_Feed_Cache``` became depricated in wp5.6, so the cache class was changed.

And, Since writing the cache file failed, I changed to writing to the temporary directory

Cache file write error log
```
[15-Jan-2021 16:13:42 UTC] PHP Warning:  ./cache is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable. in /var/www/html/sample/wp-includes/class-simplepie.php on line 1510
```
