### PR TITLE
Remove undefined unused param.

### DIFF
--- a/feedwordpress.php
+++ b/feedwordpress.php
@@ -2289,7 +2289,7 @@ EOMAIL;
 	} /* FeedWordPress::param () */
 
 	static function post( $key, $default = null, $sanitizer = null ) {
-		return self::sanitized_parameter( MyPHP::post( $key, $default, $type ), $sanitizer );
+		return self::sanitized_parameter( MyPHP::post( $key, $default ), $sanitizer );
 	} /* FeedWordPress::post () */
 
 	static function shallow_sanitize( $item, $sanitizer = null ) {


### PR DESCRIPTION
This param is undefined, as is also not in the function definition in 
https://github.com/radgeek/feedwordpress/blob/master/externals/myphp/myphp.class.php#L53-L55

It generates an error in the logs on every page load.