### PR TITLE
Fix for running FWP polling via WP CLI

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -619,8 +619,9 @@ class SyndicatedPost {
 	 * @uses apply_filters()
 	 */
 	static function normalize_guid_prefix () {
-		$url = trailingslashit(home_url(/*path=*/ '', /*scheme=*/ 'http'));
-		return apply_filters('syndicated_item_guid_normalized_prefix', $url . '?guid=');
+		$scheme = 'http';
+		$url = trailingslashit(home_url(/*path=*/ '', $scheme));
+		return apply_filters('syndicated_item_guid_normalized_prefix', $url . '?guid=', $scheme);
 	} /* SyndicatedPost::normalize_guid_prefix() */
 
 	static function normalize_guid ($guid) {
@@ -636,8 +637,9 @@ class SyndicatedPost {
 	} /* SyndicatedPost::normalize_guid() */
 
 	static function alternative_guid_prefix () {
-		$url = trailingslashit(home_url(/*path=*/ '', /*scheme=*/ 'https'));
-		return apply_filters('syndicated_item_guid_normalized_prefix', $url . '?guid=');
+		$scheme = 'https';
+		$url = trailingslashit(home_url(/*path=*/ '', $scheme));
+		return apply_filters('syndicated_item_guid_normalized_prefix', $url . '?guid=', $scheme);
 	}
 	static function alternative_guid ($guid) {
 		$guid = trim($guid);


### PR DESCRIPTION
Legacy versions of WP CLI used to support `home_url()` as expected - respecting the `$scheme` parameter, however modern versions of WP CLI actually force the scheme to be that set in the database for the particular site.

This means that the normal and alternative guid prefixes are the same when running under modern WP CLIs which means that the queries to find the existing versions of posts will not necessarily find the posts when WP CLI is upgraded from legacy to modern versions and so duplicate posts are created.

The easiest fix here is to also pass the `$scheme` argument to the `syndicated_item_guid_normalized_prefix` filter, so we can know which guid scheme we are working on and allows us to allow the correct scheme to be used.