### PR TITLE
Support explicitly namespaced `atom:updated`  field

### DIFF
--- a/syndicatedpost.class.php
+++ b/syndicatedpost.class.php
@@ -547,6 +547,8 @@ class SyndicatedPost {
 			$date = $this->item['modified'];
 		elseif (isset($this->item['updated'])):			// Atom 1.0
 			$date = $this->item['updated'];
+		elseif (isset($this->item['atom']['updated'])):			// Atom 1.0
+			$date = $this->item['atom']['updated'];
 		endif;
 
 		if (strlen($date) > 0) :


### PR DESCRIPTION
We've seen many feeds with 'atom:updated' fields and if we don't support these we don't get updates