### PR TITLE
Fix header handling issue by initializing $this->headers as an empty array

### DIFF
--- a/extend/SimplePie/feedwordpie_file.class.php
+++ b/extend/SimplePie/feedwordpie_file.class.php
@@ -100,7 +100,7 @@ class FeedWordPie_File extends WP_SimplePie_File {
 				$this->error   = 'WP HTTP Error: ' . $res->get_error_message();
 				$this->success = false;
 			else :
-				$this->headers     = wp_remote_retrieve_headers( $res );
+				$this->headers = array();
 				$this->body        = wp_remote_retrieve_body( $res );
 				$this->status_code = wp_remote_retrieve_response_code( $res );
 			endif;


### PR DESCRIPTION
### Summary

This pull request fixes an issue where HTTP headers are assigned to `$this->headers`,
which FeedWordPress does not actually use and sometimes fails to handle correctly.

### Details

- Plugin version tested: **FeedWordPress 2024.1119**
- File modified:
feedwordpress/extend/SimplePie/feedwordpie_file.class.php


### Change made

```php
// Before
$this->headers = wp_remote_retrieve_headers( $res );

// After
$this->headers = array();
