### PR TITLE
Fix fatal error for empty RSS feed in feeds-page.php

### DIFF
--- a/feeds-page.php
+++ b/feeds-page.php
@@ -1161,7 +1161,7 @@ class FeedWordPressFeedsPage extends FeedWordPressAdminPage {
 					<?php
 					$link = null;
 					$post = null;
-					if ( !is_wp_error($rss) and count($rss->items) > 0):
+					if ( !is_wp_error($rss) && !empty($rss->items) && is_array($rss->items) ):
 						// Prepare to display Sample Item
 						$link = new MagpieMockLink(array('simplepie' => $pie, 'magpie' => $rss), $f);
 						$post = new SyndicatedPost(array('simplepie' => $rss->originals[0], 'magpie' => $rss->items[0]), $link);


### PR DESCRIPTION
Replace count($rss->items) with a check for !empty($rss->items) and is_array($rss->items) to prevent a fatal error when an RSS feed has no items (line 1164).