### PR TITLE
Add complete compatibility directory for SimplePie 1.9.0

### DIFF
--- a/extend/SimplePie/1.9.0/feedwordpie_cache.class.php
+++ b/extend/SimplePie/1.9.0/feedwordpie_cache.class.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * FeedWordPie_Cache class. Provides customized feed caching for FeedWordPress.
+ * This is derived (currently, just copied and combined) from WordPress Core
+ * wp-includes/class-wp-feed-cache.php ("Feed API: WP_Feed_Cache_Transient class")
+ * and from wp-includes/SimplePie/Cache.php ("SimplePie_Cache"), pursuant to the
+ * terms of the GPL.
+ *
+ * The wrapper class WP_Feed_Cache was deprecated in WordPress 5.6, but its intended
+ * replacement, WP_Feed_Cache_Transient, is currently NOT a subclass of SimplePie_Cache
+ * which causes problems registering it as a cache class in some versions of SimplePie.
+ * Solution: For now, let's copy the class over under a new name, but this time, inherit
+ * from SimplePie_Cache. (I am doing it this way because I might want to make some real
+ * changs to the implementation of caching, in order to better support typical FeedWordPress
+ * use cases. In the meantime, this should at least stop the PHP warnings and the failure
+ * to correctly cache feed contents that users are encountering with WordPress 5.6.)
+ *
+ * @version 2021.0118
+ */
+
+/**
+ * Core class used to implement feed cache transients.
+ *
+ * @since 2.8.0
+ */
+class FeedWordPie_Cache extends SimplePie\Cache implements SimplePie\Cache\Base {
+
+	/**
+	 * Holds the transient name.
+	 *
+	 * @since 2.8.0
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Holds the transient mod name.
+	 *
+	 * @since 2.8.0
+	 * @var string
+	 */
+	public $mod_name;
+
+	/**
+	 * Holds the cache duration in seconds.
+	 *
+	 * Defaults to 43200 seconds (12 hours).
+	 *
+	 * @since 2.8.0
+	 * @var int
+	 */
+	public $lifetime = 43200;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.8.0
+	 * @since 3.2.0 Updated to use a PHP5 constructor.
+	 *
+	 * @param string $location  URL location (scheme is used to determine handler).
+	 * @param string $filename  Unique identifier for cache object.
+	 * @param string $extension 'spi' or 'spc'.
+	 */
+	public function __construct( $location, $filename, $extension ) {
+		$this->name     = 'feed_' . $filename;
+		$this->mod_name = 'feed_mod_' . $filename;
+
+		$lifetime = $this->lifetime;
+		/**
+		 * Filters the transient lifetime of the feed cache.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param int    $lifetime Cache duration in seconds. Default is 43200 seconds (12 hours).
+		 * @param string $filename Unique identifier for the cache object.
+		 */
+		$this->lifetime = apply_filters( 'wp_feed_cache_transient_lifetime', $lifetime, $filename );
+	}
+
+	/**
+	 * Sets the transient.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param SimplePie $data Data to save.
+	 * @return true Always true.
+	 */
+	public function save( $data ) {
+		if ( $data instanceof SimplePie ) {
+			$data = $data->data;
+		}
+
+		set_transient( $this->name, $data, $this->lifetime );
+		set_transient( $this->mod_name, time(), $this->lifetime );
+		return true;
+	}
+
+	/**
+	 * Gets the transient.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return mixed Transient value.
+	 */
+	public function load() {
+		return get_transient( $this->name );
+	}
+
+	/**
+	 * Gets mod transient.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return mixed Transient value.
+	 */
+	public function mtime() {
+		return get_transient( $this->mod_name );
+	}
+
+	/**
+	 * Sets mod transient.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return bool False if value was not set and true if value was set.
+	 */
+	public function touch() {
+		return set_transient( $this->mod_name, time(), $this->lifetime );
+	}
+
+	/**
+	 * Deletes transients.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return true Always true.
+	 */
+	public function unlink() {
+		delete_transient( $this->name );
+		delete_transient( $this->mod_name );
+		return true;
+	}
+
+	/**
+	 * Create a new SimplePie_Cache object
+	 *
+	 * @param string $location URL location (scheme is used to determine handler)
+	 * @param string $filename Unique identifier for cache object
+	 * @param string $extension 'spi' or 'spc'
+	 * @return SimplePie_Cache_Base Type of object depends on scheme of `$location`
+	 */
+	public static function get_handler($location, $filename, $extension)
+	{
+
+		$type = explode(':', $location, 2);
+		$type = $type[0];
+		if ( !empty(self::$handlers[$type]))
+		{
+			$class = self::$handlers[$type];
+			return $class($location, $filename, $extension);
+		}
+		
+		return new FeedWordPie_Cache($location, $filename, $extension);
+	}
+
+	/**
+	 * Create a new SimplePie_Cache object
+	 *
+	 * @deprecated Use {@see get_handler} instead
+	 */
+	public function create($location, $filename, $extension)
+	{
+		trigger_error('Cache::create() has been replaced with Cache::get_handler(). Switch to the registry system to use this.', E_USER_DEPRECATED);
+		return self::get_handler($location, $filename, $extension);
+	}
+
+}

--- a/extend/SimplePie/1.9.0/feedwordpie_item.class.php
+++ b/extend/SimplePie/1.9.0/feedwordpie_item.class.php
@@ -1,0 +1,56 @@
+<?php
+
+class FeedWordPie_Item extends SimplePie_Item {
+
+	function get_id ($hash = false, $fn = 'md5') {
+		return apply_filters('feedwordpie_item_get_id', parent::get_id($hash, $fn), $hash, $this, $fn);
+	}
+
+	function get_title () {
+		return apply_filters('feedwordpie_item_get_title', parent::get_title(), $this);
+	}
+
+	function get_description ($description_only = false) {
+		return apply_filters('feedwordpie_item_get_description', parent::get_description($description_only), $description_only, $this);
+	}
+
+	function get_content ($content_only = false) {
+		return apply_filters('feedwordpie_item_get_content', parent::get_content($content_only), $content_only, $this);
+	}
+
+	function get_categories () {
+		return apply_filters('feedwordpie_item_get_categories', parent::get_categories(), $this);
+	}
+
+	function get_authors () {
+		return apply_filters('feedwordpie_item_get_authors', parent::get_authors(), $this);
+	}
+	function get_contributors () {
+		return apply_filters('feedwordpie_item_get_contributors', parent::get_contributors(), $this);
+	}
+	function get_copyright () {
+		return apply_filters('feedwordpie_item_get_copyright', parent::get_copyright(), $this);
+	}
+	function get_date ($date_format = 'j F Y, g:i a') {
+		return apply_filters('feedwordpie_item_get_date', parent::get_date($date_format), $date_format, $this);
+	}
+	function get_local_date ($date_format = '%c') {
+		return apply_filters('feedwordpie_item_get_local_date', parent::get_local_date($date_format), $date_format, $this);
+	}
+	function get_links ($rel = 'alternate') {
+		return apply_filters('feedwordpie_item_get_links', parent::get_links($rel), $rel, $this);
+	}
+	function get_enclosures () {
+		return apply_filters('feedwordpie_item_get_enclosures', parent::get_enclosures(), $this);
+	}
+	function get_latitude () {
+		return apply_filters('feedwordpie_item_get_latitude', parent::get_latitude(), $this);
+	}
+	function get_longitude () {
+		return apply_filters('feedwordpie_item_get_longitude', parent::get_longitude(), $this);
+	}
+	function get_source () {
+		return apply_filters('feedwordpie_item_get_source', parent::get_source(), $this);
+	}
+} /* class FeedWordPie_Item */
+

--- a/extend/SimplePie/1.9.0/feedwordpie_parser.class.php
+++ b/extend/SimplePie/1.9.0/feedwordpie_parser.class.php
@@ -1,0 +1,128 @@
+<?php
+class FeedWordPie_Parser extends SimplePie_Parser {
+    var $xmlns_stack = array();
+    var $xmlns_current = array();
+
+    function reset_parser(&$xml) {
+        $this->namespace = array('');
+        $this->element = array('');
+        $this->xml_base = array('');
+        $this->xml_base_explicit = array(false);
+        $this->xml_lang = array('');
+        $this->data = array();
+        $this->datas = array(array());
+        $this->current_xhtml_construct = -1;
+        $this->xmlns_stack = array();
+        $this->xmlns_current = array();
+
+        if (is_resource($xml)) {
+            xml_parser_free($xml);
+        }
+
+        $xml = xml_parser_create_ns($this->encoding, $this->separator);
+        xml_parser_set_option($xml, XML_OPTION_SKIP_WHITE, 1);
+        xml_parser_set_option($xml, XML_OPTION_CASE_FOLDING, 0);
+        xml_set_object($xml, $this);
+        xml_set_character_data_handler($xml, 'cdata');
+        xml_set_element_handler($xml, 'tag_open', 'tag_close');
+        xml_set_start_namespace_decl_handler($xml, 'start_xmlns');
+    }
+
+    public function parse(string &$data, string $encoding, string $url = '') {
+        $data = apply_filters('feedwordpress_parser_parse', $data, $encoding, $this, $url);
+
+        if (strtoupper($encoding) === 'US-ASCII') {
+            $this->encoding = 'UTF-8';
+        } else {
+            $this->encoding = $encoding;
+        }
+
+        // Strip BOM
+        if (substr($data, 0, 4) === "\x00\x00\xFE\xFF" || substr($data, 0, 4) === "\xFF\xFE\x00\x00") {
+            $data = substr($data, 4);
+        } elseif (substr($data, 0, 2) === "\xFE\xFF" || substr($data, 0, 2) === "\xFF\xFE") {
+            $data = substr($data, 2);
+        } elseif (substr($data, 0, 3) === "\xEF\xBB\xBF") {
+            $data = substr($data, 3);
+        }
+
+        if (substr($data, 0, 5) === '<?xml' && ($pos = strpos($data, '?>')) !== false) {
+            $declaration = $this->registry->create('XML_Declaration_Parser', array(substr($data, 5, $pos - 5)));
+            if ($declaration->parse()) {
+                $data = substr($data, $pos + 2);
+                $data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' . "\n" . self::declare_html_entities() . $data;
+            }
+        }
+
+        $xml = xml_parser_create_ns($this->encoding, $this->separator);
+        xml_parser_set_option($xml, XML_OPTION_SKIP_WHITE, 1);
+        xml_parser_set_option($xml, XML_OPTION_CASE_FOLDING, 0);
+        xml_set_object($xml, $this);
+        xml_set_character_data_handler($xml, 'cdata');
+        xml_set_element_handler($xml, 'tag_open', 'tag_close');
+        xml_set_start_namespace_decl_handler($xml, 'start_xmlns');
+
+        $results = $this->do_xml_parse_attempt($xml, $data);
+        $parseResults = $results[0];
+
+        if (!$parseResults) {
+            $this->error_code = xml_get_error_code($xml);
+            $this->error_string = xml_error_string($this->error_code);
+            xml_parser_free($xml);
+            return false;
+        }
+
+        xml_parser_free($xml);
+        return true;
+    }
+
+    public function do_xml_parse_attempt($xml, $data) {
+        xml_set_start_namespace_decl_handler($xml, 'start_xmlns');
+        $parseResults = xml_parse($xml, $data, true);
+
+        if (!$parseResults && (xml_get_error_code($xml) == 26)) {
+            $data = $this->html_convert_entities($data);
+            $this->reset_parser($xml);
+            $parseResults = xml_parse($xml, $data, true);
+        }
+
+        return array($parseResults, $data);
+    }
+
+    function tag_open($parser, $tag, $attributes) {
+        $ret = parent::tag_open($parser, $tag, $attributes);
+        if ($this->current_xhtml_construct < 0) {
+            $this->data['xmlns'] = $this->xmlns_current;
+            $this->xmlns_stack[] = $this->xmlns_current;
+        }
+        return $ret;
+    }
+
+    function tag_close($parser, $tag) {
+        if ($this->current_xhtml_construct < 0) {
+            $this->xmlns_current = array_pop($this->xmlns_stack);
+        }
+        return parent::tag_close($parser, $tag);
+    }
+
+    function start_xmlns($parser, $prefix, $uri) {
+        if (!$prefix) $prefix = '';
+        if ($this->current_xhtml_construct < 0) {
+            $this->xmlns_current[$prefix] = $uri;
+        }
+        return true;
+    }
+
+    public function html_convert_entities($string) {
+        return preg_replace_callback('/&([a-zA-Z][a-zA-Z0-9]+);/S', array($this, 'convert_entity'), $string);
+    }
+
+    public function convert_entity($matches) {
+        static $table = array('quot'=>'&#34;','amp'=>'&#38;','lt'=>'&#60;','gt'=>'&#62;','nbsp'=>'&#160;','copy'=>'&#169;','reg'=>'&#174;');
+        return isset($table[$matches[1]]) ? $table[$matches[1]] : '';
+    }
+
+    public static function declare_html_entities() {
+        return '<!DOCTYPE html [ <!ENTITY nbsp "&#x00A0;"> <!ENTITY copy "&#x00A9;"> <!ENTITY reg "&#x00AE;"> ]>';
+    }
+}

--- a/feedwordpress.php
+++ b/feedwordpress.php
@@ -2127,7 +2127,7 @@ class FeedWordPress {
 	static function diagnostic( $level, $out, $persist = null, $since = null, $mostRecent = null ) {
 		global $feedwordpress_admin_footer;
 
-		$output = get_option( 'feedwordpress_diagnostics_output', array() );
+		$output = (array) get_option( 'feedwordpress_diagnostics_output', array() );
 		$dlog   = get_option( 'feedwordpress_diagnostics_log', array() );
 
 		$diagnostic_nesting = count( explode( ":", $level ) );

--- a/syndicatedlink.class.php
+++ b/syndicatedlink.class.php
@@ -618,7 +618,8 @@ class SyndicatedLink {
 			$author_rules = explode("\n\n", $this->settings['map authors']);
 			$ma = array();
 			foreach ($author_rules as $rule) :
-				list($rule_type, $author_name, $author_action) = explode("\n", $rule);
+				$parts = array_pad(explode("\n", $rule), 3, '');
+				list($rule_type, $author_name, $author_action) = $parts;
 
 				// Normalize for case and whitespace
 				$rule_type = strtolower(trim($rule_type));


### PR DESCRIPTION
This PR adds a dedicated 1.9.0 directory to the SimplePie extensions, following the existing versioning pattern.

**Problem:**
When running on WordPress 6.9+ (SimplePie 1.9.0), FeedWordPress falls back to the minimalist default parser. This parser lacks namespace tracking, which causes custom metadata tags like $(prefix:tag) to return none.

**Solution:**

- Created extend/SimplePie/1.9.0/.
- Implemented an updated feedwordpie_parser.class.php that restores the xmlns_stack logic from version 1.8.1.
- Updated the parser to comply with SimplePie 1.9.0 by making declare_html_entities() a static method, preventing Fatal Errors on modern PHP/SimplePie environments.
- Included feedwordpie_cache.class.php and feedwordpie_item.class.php to ensure a complete, functional parser suite for this version.

Tested. Successfully restores custom namespace parsing.

Fixes: #168 